### PR TITLE
XAPI Audit#1

### DIFF
--- a/aggregator/src/ormp.aggregator.ts
+++ b/aggregator/src/ormp.aggregator.ts
@@ -1,6 +1,6 @@
 // Find all our documentation at https://docs.near.org
 import { NearBindgen, near, call, view, migrate, assert, NearPromise, AccountId } from "near-sdk-js";
-import { Aggregator, Answer, ChainId, DataSource, MpcConfig, PublishChainConfig, Report, ReporterRequired, RequestId, Response, Staked, Timestamp } from "./abstract/aggregator.abstract";
+import { Aggregator, Answer, ChainId, DataSource, MpcConfig, MpcOptions, PublishChainConfig, Report, ReporterRequired, RequestId, Response, Staked, Timestamp } from "./abstract/aggregator.abstract";
 import { ContractSourceMetadata, Standard } from "../../common/src/standard.abstract";
 
 @NearBindgen({})
@@ -104,13 +104,13 @@ class OrmpAggregator extends Aggregator {
   /// Calls
 
   @call({})
-  publish_external({ request_id, nonce, gas_limit, max_fee_per_gas, max_priority_fee_per_gas }: { request_id: RequestId; nonce: string; gas_limit: string; max_fee_per_gas: string; max_priority_fee_per_gas: string; }): NearPromise {
-    return super._publish({ request_id, nonce, gas_limit, max_fee_per_gas, max_priority_fee_per_gas });
+  publish_external({ request_id, mpc_options }: { request_id: RequestId; mpc_options: MpcOptions }): NearPromise {
+    return super._publish({ request_id, mpc_options });
   }
 
   @call({ privateFunction: true })
-  publish_callback({ request_id, nonce, gas_limit, max_fee_per_gas, max_priority_fee_per_gas }: { request_id: RequestId; nonce: string; gas_limit: string; max_fee_per_gas: string; max_priority_fee_per_gas: string; }): void {
-    super._publish_callback({ request_id, nonce, gas_limit, max_fee_per_gas, max_priority_fee_per_gas });
+  publish_callback({ request_id, mpc_options }: { request_id: RequestId; mpc_options: MpcOptions }): void {
+    super._publish_callback({ request_id, mpc_options });
   }
 
   @call({ privateFunction: true })
@@ -121,6 +121,16 @@ class OrmpAggregator extends Aggregator {
   @call({ payableFunction: true })
   report({ request_id, answers, reward_address }: { request_id: RequestId; answers: Answer[]; reward_address: string; }): NearPromise {
     return super._report({ request_id, answers, reward_address });
+  }
+
+  @call({})
+  sync_publish_config_to_remote({ chain_id, mpc_options }: { chain_id: ChainId; mpc_options: MpcOptions; }): NearPromise {
+    return super._sync_publish_config_to_remote({ chain_id, mpc_options });
+  }
+
+  @call({ privateFunction: true })
+  sync_publish_config_to_remote_callback({ chain_id, mpc_options, call_data, version }: { chain_id: ChainId; mpc_options: MpcOptions; call_data: Uint8Array; version: string; }): void {
+    return super._sync_publish_config_to_remote_callback({ chain_id, mpc_options, call_data, version });
   }
 
   @call({ payableFunction: true })

--- a/xapi-consumer/contracts/ConsumerExample.sol
+++ b/xapi-consumer/contracts/ConsumerExample.sol
@@ -17,7 +17,7 @@ contract ConsumerExample {
         xapi = IXAPI(xapiAddress);
     }
 
-    function makeRequest(string memory aggregator) external payable {
+    function makeRequest(address aggregator) external payable {
         string memory requestData = "{'hello':'world'}";
         uint256 requestId = xapi.makeRequest{value: msg.value}(requestData, this.fulfillCallback.selector, aggregator);
         emit RequestMade(requestId, requestData);

--- a/xapi/contracts/XAPI.sol
+++ b/xapi/contracts/XAPI.sol
@@ -7,19 +7,19 @@ import "./interfaces/IXAPI.sol";
 contract XAPI is IXAPI, Ownable2Step {
     uint256 public requestCount;
     mapping(uint256 => Request) public requests;
-    mapping(string => AggregatorConfig) public aggregatorConfigs;
+    mapping(address => AggregatorConfig) public aggregatorConfigs;
     mapping(address => uint256) public rewards;
 
     constructor() Ownable(msg.sender) {}
 
-    function makeRequest(string memory requestData, bytes4 callbackFunction, string memory aggregator)
+    function makeRequest(string memory requestData, bytes4 callbackFunction, address exAggregator)
         external
         payable
         returns (uint256)
     {
         require(msg.sender != address(this), "CANT call self");
-        AggregatorConfig memory aggregatorConfig = aggregatorConfigs[aggregator];
-        require(aggregatorConfig.fulfillAddress != address(0), "!Aggregator");
+        AggregatorConfig memory aggregatorConfig = aggregatorConfigs[exAggregator];
+        require(aggregatorConfig.rewardAddress != address(0), "!Aggregator");
         require(!aggregatorConfig.suspended, "Suspended");
 
         uint256 feeRequired = aggregatorConfig.perReporterFee * aggregatorConfig.quorum + aggregatorConfig.publishFee;
@@ -33,24 +33,24 @@ contract XAPI is IXAPI, Ownable2Step {
             callbackFunction: callbackFunction,
             status: RequestStatus.Pending,
             payment: msg.value,
-            aggregator: aggregator,
-            fulfillAddress: aggregatorConfig.fulfillAddress,
+            aggregator: aggregatorConfig.aggregator,
+            exAggregator: exAggregator,
             response: ResponseData({reporters: new address[](0), result: new bytes(0)}),
             requestData: requestData
         });
-        emit RequestMade(requestId, aggregator, requestData, msg.sender);
+        emit RequestMade(requestId, aggregatorConfig.aggregator, requestData, msg.sender);
         return requestId;
     }
 
     function fulfill(uint256 requestId, ResponseData memory response) external {
         Request storage request = requests[requestId];
         require(decodeChainId(requestId) == block.chainid, "!chainId");
-        require(msg.sender == request.fulfillAddress, "!Fulfill address");
+        require(msg.sender == request.exAggregator, "!exAggregator address");
         require(request.status == RequestStatus.Pending, "!Pending");
 
         request.response = response;
 
-        AggregatorConfig memory aggregatorConfig = aggregatorConfigs[request.aggregator];
+        AggregatorConfig memory aggregatorConfig = aggregatorConfigs[msg.sender];
         // Avoid changing the reward configuration after the request but before the response to obtain the contract balance
         require(
             aggregatorConfig.publishFee + aggregatorConfig.perReporterFee * response.reporters.length <= request.payment,
@@ -96,12 +96,11 @@ contract XAPI is IXAPI, Ownable2Step {
         string memory aggregator,
         uint256 perReporterFee,
         uint256 publishFee,
-        address fulfillAddress,
         address rewardAddress,
         uint8 quorum
-    ) external onlyOwner {
-        aggregatorConfigs[aggregator] = AggregatorConfig({
-            fulfillAddress: fulfillAddress,
+    ) external {
+        aggregatorConfigs[msg.sender] = AggregatorConfig({
+            aggregator: aggregator,
             perReporterFee: perReporterFee,
             publishFee: publishFee,
             rewardAddress: rewardAddress,
@@ -109,13 +108,14 @@ contract XAPI is IXAPI, Ownable2Step {
             suspended: false
         });
 
-        emit AggregatorConfigSet(aggregator, perReporterFee, publishFee, fulfillAddress, rewardAddress);
+        emit AggregatorConfigSet(msg.sender, perReporterFee, publishFee, aggregator, rewardAddress);
     }
 
-    function suspendAggregator(string memory aggregator) external onlyOwner {
-        aggregatorConfigs[aggregator].suspended = true;
+    function suspendAggregator() external {
+        require(aggregatorConfigs[msg.sender].rewardAddress != address(0), "!Aggregator");
+        aggregatorConfigs[msg.sender].suspended = true;
 
-        emit AggregatorSuspended(aggregator);
+        emit AggregatorSuspended(msg.sender, aggregatorConfigs[msg.sender].aggregator);
     }
 
     function encodeRequestId(uint256 count) internal view returns (uint256) {

--- a/xapi/contracts/interfaces/IXAPI.sol
+++ b/xapi/contracts/interfaces/IXAPI.sol
@@ -10,7 +10,7 @@ struct Request {
     address callbackContract;
     bytes4 callbackFunction;
     RequestStatus status;
-    address fulfillAddress;
+    address exAggregator;
     ResponseData response;
     uint256 payment;
 }
@@ -27,7 +27,8 @@ struct ResponseData {
 }
 
 struct AggregatorConfig {
-    address fulfillAddress;
+    // Aggregator account on near
+    string aggregator;
     address rewardAddress;
     uint256 perReporterFee;
     uint256 publishFee;
@@ -40,15 +41,15 @@ interface IXAPI {
     event Fulfilled(uint256 indexed requestId, ResponseData response, RequestStatus indexed status);
     event RewardsWithdrawn(address indexed withdrawer, uint256 amount);
     event AggregatorConfigSet(
-        string indexed aggregator,
+        address indexed exAggregator,
         uint256 perReporterFee,
         uint256 publishFee,
-        address fulfillAddress,
+        string aggregator,
         address rewardAddress
     );
-    event AggregatorSuspended(string indexed aggregator);
+    event AggregatorSuspended(address indexed exAggregator, string indexed aggregator);
 
-    function makeRequest(string memory requestData, bytes4 callbackFunction, string memory aggregator)
+    function makeRequest(string memory requestData, bytes4 callbackFunction, address exAggregator)
         external
         payable
         returns (uint256);
@@ -59,14 +60,14 @@ interface IXAPI {
 
     function withdrawRewards() external;
 
+    // Should be called by Aggregator mpc
     function setAggregatorConfig(
         string memory aggregator,
         uint256 perReporterFee,
         uint256 publishFee,
-        address fulfillAddress,
         address rewardAddress,
         uint8 quorum
     ) external;
 
-    function suspendAggregator(string memory aggregator) external;
+    function suspendAggregator() external;
 }

--- a/xapi/contracts/interfaces/IXAPI.sol
+++ b/xapi/contracts/interfaces/IXAPI.sol
@@ -30,9 +30,8 @@ struct AggregatorConfig {
     // Aggregator account on near
     string aggregator;
     address rewardAddress;
-    uint256 perReporterFee;
+    uint256 reportersFee;
     uint256 publishFee;
-    uint8 quorum;
     bool suspended;
 }
 
@@ -42,7 +41,7 @@ interface IXAPI {
     event RewardsWithdrawn(address indexed withdrawer, uint256 amount);
     event AggregatorConfigSet(
         address indexed exAggregator,
-        uint256 perReporterFee,
+        uint256 reportersFee,
         uint256 publishFee,
         string aggregator,
         address rewardAddress
@@ -63,11 +62,10 @@ interface IXAPI {
     // Should be called by Aggregator mpc
     function setAggregatorConfig(
         string memory aggregator,
-        uint256 perReporterFee,
+        uint256 reportersFee,
         uint256 publishFee,
-        address rewardAddress,
-        uint8 quorum
+        address rewardAddress
     ) external;
 
-    function suspendAggregator() external;
+    function suspendAggregator(address exAggregator) external;
 }

--- a/xapi/test/XAPI.js
+++ b/xapi/test/XAPI.js
@@ -29,30 +29,24 @@ describe("XAPI", function () {
   describe("Aggregator Configuration", function () {
     it("Should set aggregator config correctly", async function () {
       const { xapi, owner } = await loadFixture(deployXAPIFixture);
-      await xapi.setAggregatorConfig("testAggregator", 100, 1000, owner.address, owner.address, 5);
-      const config = await xapi.aggregatorConfigs("testAggregator");
-      expect(config.fulfillAddress).to.equal(owner.address);
+      await xapi.setAggregatorConfig("testAggregator", 100, 1000, owner.address, 5);
+      const config = await xapi.aggregatorConfigs(owner.address);
+      expect(config.aggregator).to.equal("testAggregator");
       expect(config.perReporterFee).to.equal(100);
       expect(config.publishFee).to.equal(1000);
       expect(config.suspended).to.be.false;
-    });
-
-    it("Should only allow owner to set aggregator config", async function () {
-      const { xapi, otherAccount } = await loadFixture(deployXAPIFixture);
-      await expect(xapi.connect(otherAccount).setAggregatorConfig("testAggregator", 100, 1000, owner.address, owner.address, 5))
-        .to.be.reverted;
     });
   });
 
   describe("Make Request", function () {
     it("Should create a new request", async function () {
       const { xapi, owner } = await loadFixture(deployXAPIFixture);
-      await xapi.setAggregatorConfig("testAggregator", 100, 1000, owner.address, owner.address, 5);
+      await xapi.setAggregatorConfig("testAggregator", 100, 1000, owner.address, 5);
       const requestData = "test data";
       const callbackFunction = "0x12345678";
       const requestFee = 1500; // 5 * 100 + 1000
 
-      await expect(xapi.makeRequest(requestData, callbackFunction, "testAggregator", { value: requestFee }))
+      await expect(xapi.makeRequest(requestData, callbackFunction, owner.address, { value: requestFee }))
         .to.emit(xapi, "RequestMade")
         .withArgs(anyValue, "testAggregator", requestData, owner.address);
     });
@@ -62,11 +56,11 @@ describe("XAPI", function () {
     it("Should fulfill a request", async function () {
       const { xapi, owner } = await loadFixture(deployXAPIFixture);
       // Setup and make a request first
-      await xapi.setAggregatorConfig("testAggregator", 100, 1000, owner.address, owner.address, 5);
+      await xapi.setAggregatorConfig("testAggregator", 100, 1000, owner.address, 5);
       const requestData = "test data";
       const callbackFunction = "0x12345678";
       const requestFee = 1500;
-      await xapi.makeRequest(requestData, callbackFunction, "testAggregator", { value: requestFee });
+      await xapi.makeRequest(requestData, callbackFunction, owner.address, { value: requestFee });
 
       const chainId = await ethers.provider.getNetwork().then(n => n.chainId);
       const requestId = encodeRequestId(chainId, 1);


### PR DESCRIPTION
https://github.com/itering/internal-security-audit/pull/137#issuecomment-2403856456

### XAPI
- Rename fulfillAddress to exAggregator
- Use exAggregator as aggregatorConfigs' key
- Allow anyone to set aggregatorConfig
- Use exAggregator to make request
- Replace perReporterFee * quorum with reportersFee

### Aggregator
- Organize nonce and fee options in MpcOptions
- Emit SetPublishChainConfigEvent
- Aggregator can sync publish config to remote chain through mpc